### PR TITLE
Handle uppercase CSS property names

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ function callback(dashChar, char)
 
 function camelCaseCSS(property)
 {
+	property = property.toLowerCase();
+
 	// NOTE :: IE8's "styleFloat" is intentionally not supported
 	if (property === "float") return "cssFloat";
 	

--- a/test.js
+++ b/test.js
@@ -11,9 +11,9 @@ it("should work", function(done)
 	expect( camelCaseCSS("-WEBKIT-BORDER-RADIUS") ).to.equal("WebkitBorderRadius");
 	expect( camelCaseCSS("-webkIT-borDer-rADIUS") ).to.equal("WebkitBorderRadius");
 	expect( camelCaseCSS("-moz-border-radius")    ).to.equal("MozBorderRadius");
-	expect( camelCaseCSS("-MOZ-BORDER-RADIUS") ).to.equal("MozBorderRadius");
+	expect( camelCaseCSS("-MOZ-BORDER-RADIUS")    ).to.equal("MozBorderRadius");
 	expect( camelCaseCSS("-ms-border-radius")     ).to.equal("msBorderRadius");
-	expect( camelCaseCSS("-MS-BORDER-RADIUS") ).to.equal("msBorderRadius");
+	expect( camelCaseCSS("-MS-BORDER-RADIUS")     ).to.equal("msBorderRadius");
 	expect( camelCaseCSS("border-radius")         ).to.equal("borderRadius");
 	expect( camelCaseCSS("BORDER-RADIUS")         ).to.equal("borderRadius");
 	

--- a/test.js
+++ b/test.js
@@ -15,6 +15,7 @@ it("should work", function(done)
 	expect( camelCaseCSS("-ms-border-radius")     ).to.equal("msBorderRadius");
 	expect( camelCaseCSS("-MS-BORDER-RADIUS") ).to.equal("msBorderRadius");
 	expect( camelCaseCSS("border-radius")         ).to.equal("borderRadius");
+	expect( camelCaseCSS("BORDER-RADIUS")         ).to.equal("borderRadius");
 	
 	expect( camelCaseCSS("float") ).to.equal("cssFloat");
 	

--- a/test.js
+++ b/test.js
@@ -8,8 +8,12 @@ var expect = require("chai").expect;
 it("should work", function(done)
 {
 	expect( camelCaseCSS("-webkit-border-radius") ).to.equal("WebkitBorderRadius");
+	expect( camelCaseCSS("-WEBKIT-BORDER-RADIUS") ).to.equal("WebkitBorderRadius");
+	expect( camelCaseCSS("-webkIT-borDer-rADIUS") ).to.equal("WebkitBorderRadius");
 	expect( camelCaseCSS("-moz-border-radius")    ).to.equal("MozBorderRadius");
+	expect( camelCaseCSS("-MOZ-BORDER-RADIUS") ).to.equal("MozBorderRadius");
 	expect( camelCaseCSS("-ms-border-radius")     ).to.equal("msBorderRadius");
+	expect( camelCaseCSS("-MS-BORDER-RADIUS") ).to.equal("msBorderRadius");
 	expect( camelCaseCSS("border-radius")         ).to.equal("borderRadius");
 	
 	expect( camelCaseCSS("float") ).to.equal("cssFloat");


### PR DESCRIPTION
CSS property names are case-*insensitive*, but JS is not.

Before this change, a property like `-MOZ-HYPHENS` would end up as `MOZHYPHENS` — not what we want. I think all we need to do is lowercase the property before adjusting it.

(I ran into this while working with postcss-js, cc @ai.)